### PR TITLE
Implement Room Building Replay with Autoplay

### DIFF
--- a/Assets/Scripts/DecorateRoomScreen.cs
+++ b/Assets/Scripts/DecorateRoomScreen.cs
@@ -456,19 +456,60 @@ public class DecorateRoomScreen : UILayer, Match3GameListener
 
     private void OnCompleteRoom()
     {
-        DecorateRoomScreen._003C_003Ec__DisplayClass69_0 _003C_003Ec__DisplayClass69_ = new DecorateRoomScreen._003C_003Ec__DisplayClass69_0();
-        _003C_003Ec__DisplayClass69_.nav = NavigationManager.instance;
-        _003C_003Ec__DisplayClass69_.giftBoxScreen = _003C_003Ec__DisplayClass69_.nav.GetObject<GiftBoxScreen>();
-        _003C_003Ec__DisplayClass69_.loadedRoom = this.activeRoom.loadedRoom;
-        _003C_003Ec__DisplayClass69_.arguments = default(GiftBoxScreen.ShowArguments);
-        _003C_003Ec__DisplayClass69_.arguments.title = "Room Complete";
-        _003C_003Ec__DisplayClass69_.arguments.giftsDefinition = _003C_003Ec__DisplayClass69_.loadedRoom.giftDefinition;
-        _003C_003Ec__DisplayClass69_.arguments.onComplete = new Action(_003C_003Ec__DisplayClass69_._003COnCompleteRoom_003Eb__0);
-        _003C_003Ec__DisplayClass69_.nav.GetObject<WellDoneScreen>().Show(new WellDoneScreen.InitArguments
+        // Define the logic to show the WinScreen/GiftBox
+        Action showWinScreen = null;
+        showWinScreen = delegate()
         {
-            mainText = "Room Complete",
-            onComplete = new Action(_003C_003Ec__DisplayClass69_._003COnCompleteRoom_003Eb__1)
-        });
+             NavigationManager nav = NavigationManager.instance;
+             WellDoneScreen.InitArguments initArguments = new WellDoneScreen.InitArguments();
+             initArguments.mainText = "Room Complete";
+             
+             // Define what happens when the Win Screen animation finishes or the user clicks 'Next'
+             initArguments.onComplete = delegate()
+             {
+                 nav.Pop(); // FIX: Remove WellDoneScreen from stack before showing GiftBox
+                 
+                 GiftBoxScreen giftBoxScreen = nav.GetObject<GiftBoxScreen>();
+                 GiftBoxScreen.ShowArguments showArguments = default(GiftBoxScreen.ShowArguments);
+                 showArguments.title = "Room Complete";
+                 if (this.activeRoom != null && this.activeRoom.loadedRoom != null) 
+                 {
+                    showArguments.giftsDefinition = this.activeRoom.loadedRoom.giftDefinition;
+                 }
+                 showArguments.onComplete = delegate()
+                 {
+                     nav.Pop();
+                 };
+                 giftBoxScreen.Show(showArguments);
+             };
+
+             // Define the Replay action for the button on the Win Screen
+             initArguments.onReplay = delegate()
+             {
+                 // Close the current screen (WinScreen)
+                 nav.Pop();
+                 // Restart Replay, and when done, show WinScreen again (loop)
+                 // We recursively call showWinScreen as the callback
+                  ReplayManager.instance.StartReplay(this, this.activeRoom.name, showWinScreen);
+             };
+
+             nav.GetObject<WellDoneScreen>().Show(initArguments);
+        };
+
+        // Main Logic: Check if we have replay data to show first
+        if (ReplayManager.instance != null)
+        {
+             ReplayManager.RoomReplayData roomData = ReplayManager.instance.GetRoomData(this.activeRoom.name);
+             if (roomData != null && roomData.unlockedItems.Count > 0)
+             {
+                 // Auto-play replay, then show WinScreen
+                 ReplayManager.instance.StartReplay(this, this.activeRoom.name, showWinScreen);
+                 return;
+             }
+        }
+
+        // Default: just show WinScreen
+        showWinScreen();
     }
 
     private void ShowVariations(DecorateRoomSceneVisualItem uiItem, VariationPanel.InitParams initParams)
@@ -794,6 +835,7 @@ public class DecorateRoomScreen : UILayer, Match3GameListener
             return;
         }
         uiItem.visualObjectBehaviour.visualObject.isOwned = true;
+        ReplayManager.instance.RecordPurchase(this.scene.roomName, uiItem.visualObjectBehaviour.visualObject.name);
         this.ShowVariations(uiItem, new VariationPanel.InitParams
         {
             isPurchased = true
@@ -904,7 +946,7 @@ public class DecorateRoomScreen : UILayer, Match3GameListener
     private GameObject confettiParticle;
 
     [SerializeField]
-    private VisualObjectParticles visualObjectParticles;
+    public VisualObjectParticles visualObjectParticles;
 
     private VisibilityHelper visibilityHelper = new VisibilityHelper();
 
@@ -921,10 +963,10 @@ public class DecorateRoomScreen : UILayer, Match3GameListener
     private ComponentPool visualItemsPool = new ComponentPool();
 
     [SerializeField]
-    private List<RectTransform> widgetsToHide = new List<RectTransform>();
+    public List<RectTransform> widgetsToHide = new List<RectTransform>();
 
     [SerializeField]
-    private List<RectTransform> controlWidgets = new List<RectTransform>();
+    public List<RectTransform> controlWidgets = new List<RectTransform>();
 
     [SerializeField]
     private Image progressBarSprite;

--- a/Assets/Scripts/Editor/EditorResetUtils.cs
+++ b/Assets/Scripts/Editor/EditorResetUtils.cs
@@ -1,0 +1,102 @@
+using UnityEngine;
+using UnityEditor;
+using GGMatch3;
+using System.IO;
+
+public class EditorResetUtils
+{
+    [MenuItem("Tools/Reset Game Progress")]
+    public static void ResetGameProgress()
+    {
+        Debug.Log("Resetting Game Progress...");
+
+        // 1. Clear PlayerPrefs
+        PlayerPrefs.DeleteAll();
+
+        // 2. Clear Runtime Data (if in Play Mode)
+        bool runtimeResetSuccess = false;
+        try
+        {
+            if (Application.isPlaying)
+            {
+                if (Match3StagesDB.instance != null) Match3StagesDB.instance.ResetAll();
+                if (SingletonInit<RoomsBackend>.instance != null) SingletonInit<RoomsBackend>.instance.Reset();
+                if (BehaviourSingleton<EnergyManager>.instance != null) BehaviourSingleton<EnergyManager>.instance.FillEnergy();
+                if (GGPlayerSettings.instance != null)
+                {
+                    GGPlayerSettings.instance.ResetEverything();
+                    GGPlayerSettings.instance.Save();
+                }
+                
+                // GGUIDPrivate is static or singleton
+                GGUIDPrivate.Reset();
+                
+                AWSFirehoseAnalytics awsfirehoseAnalytics = Object.FindObjectOfType<AWSFirehoseAnalytics>();
+                if (awsfirehoseAnalytics != null)
+                {
+                    awsfirehoseAnalytics.ResetModel();
+                    awsfirehoseAnalytics.sessionID = GGUID.NewGuid();
+                }
+
+                Debug.Log("Runtime Singletons Reset.");
+                runtimeResetSuccess = true;
+            }
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogWarning($"Runtime reset failed (expected if not playing): {e.Message}");
+        }
+
+        // 3. Delete Save Files (Robust method for Edit Mode)
+        if (!runtimeResetSuccess || !Application.isPlaying)
+        {
+            string[] filesToDelete = new string[]
+            {
+                "player.bytes",
+                "st.bytes",
+                "r.bytes",
+                "ownedItems.bytes",
+                "room_replay_data.json"
+            };
+
+            foreach (string filename in filesToDelete)
+            {
+                string path = Path.Combine(Application.persistentDataPath, filename);
+                if (File.Exists(path))
+                {
+                    try 
+                    {
+                        File.Delete(path);
+                        Debug.Log($"Deleted save file: {filename}");
+                    }
+                    catch (System.Exception e)
+                    {
+                        Debug.LogError($"Failed to delete {filename}: {e.Message}");
+                    }
+                }
+            }
+        }
+
+        Debug.Log("Game Reset Complete. If in Editor, hit Play to start fresh. If in Play Mode, recommended to Stop and Play again.");
+    }
+    [MenuItem("Tools/Give 100 Stars (Diamonds)")]
+    public static void Give100Stars()
+    {
+        if (!Application.isPlaying)
+        {
+            Debug.LogError("You must be in Play Mode to use this cheat!");
+            return;
+        }
+
+        if (GGPlayerSettings.instance != null && GGPlayerSettings.instance.walletManager != null)
+        {
+            GGPlayerSettings.instance.walletManager.AddCurrency(CurrencyType.diamonds, 100);
+            GGPlayerSettings.instance.walletManager.AddCurrency(CurrencyType.coins, 10000); // Give coins too just in case
+            Debug.Log("Added 100 Diamonds (Stars) and 10000 Coins!");
+        }
+        else
+        {
+             Debug.LogError("PlayerSettings or WalletManager not initialized.");
+        }
+    }
+}

--- a/Assets/Scripts/ReplayManager.cs
+++ b/Assets/Scripts/ReplayManager.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using GGMatch3;
+
+public class ReplayManager : BehaviourSingletonInit<ReplayManager>
+{
+    [Serializable]
+    public class RoomReplayData
+    {
+        public string roomName;
+        public List<string> unlockedItems = new List<string>();
+    }
+
+    [Serializable]
+    public class ReplayDataCollection
+    {
+        public List<RoomReplayData> rooms = new List<RoomReplayData>();
+    }
+
+    private ReplayDataCollection dataCollection = new ReplayDataCollection();
+    private string filePath;
+
+    public override void Init()
+    {
+        filePath = Path.Combine(Application.persistentDataPath, "room_replay_data.json");
+        LoadData();
+    }
+
+    private void LoadData()
+    {
+        if (File.Exists(filePath))
+        {
+            try
+            {
+                string json = File.ReadAllText(filePath);
+                dataCollection = JsonUtility.FromJson<ReplayDataCollection>(json);
+                if (dataCollection == null) dataCollection = new ReplayDataCollection();
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Failed to load replay data: " + e.Message);
+                dataCollection = new ReplayDataCollection();
+            }
+        }
+    }
+
+    private void SaveData()
+    {
+        try
+        {
+            string json = JsonUtility.ToJson(dataCollection, true);
+            File.WriteAllText(filePath, json);
+        }
+        catch (Exception e)
+        {
+            Debug.LogError("Failed to save replay data: " + e.Message);
+        }
+    }
+
+    public RoomReplayData GetRoomData(string roomName)
+    {
+        foreach (var room in dataCollection.rooms)
+        {
+            if (room.roomName == roomName) return room;
+        }
+        
+        var newRoom = new RoomReplayData { roomName = roomName };
+        dataCollection.rooms.Add(newRoom);
+        return newRoom;
+    }
+
+    public void RecordPurchase(string roomName, string visualObjectName)
+    {
+        var roomData = GetRoomData(roomName);
+        if (!roomData.unlockedItems.Contains(visualObjectName))
+        {
+            roomData.unlockedItems.Add(visualObjectName);
+            SaveData();
+        }
+    }
+
+    public void StartReplay(DecorateRoomScreen screen, string roomName, Action onComplete = null)
+    {
+        StartCoroutine(ReplayRoutine(screen, roomName, onComplete));
+    }
+
+    private IEnumerator ReplayRoutine(DecorateRoomScreen screen, string roomName, Action onComplete)
+    {
+        var roomData = GetRoomData(roomName);
+        if (roomData == null || roomData.unlockedItems.Count == 0)
+        {
+            Debug.LogWarning("No replay data for room: " + roomName);
+            if (onComplete != null) onComplete();
+            yield break;
+        }
+
+        DecoratingScene scene = screen.scene;
+        if (scene == null)
+        {
+             if (onComplete != null) onComplete();
+             yield break;
+        }
+
+        // Hide UI
+        GGUtil.SetActive(screen.widgetsToHide, false);
+        GGUtil.SetActive(screen.controlWidgets, false);
+        
+        // Reset Scene (Hide all purchased items)
+        List<VisualObjectBehaviour> allBehaviours = scene.visualObjectBehaviours;
+        // Create a HashSet for faster lookup, casing might matter so let's handle it
+        HashSet<string> replayItemNames = new HashSet<string>();
+        foreach(var item in roomData.unlockedItems)
+        {
+            replayItemNames.Add(item.ToLower());
+        }
+
+        foreach (var behaviour in allBehaviours)
+        {
+            if (behaviour.isPlayerControlledObject)
+            {
+                // Ensure markers (dashed lines) are OFF for replay
+                behaviour.SetMarkersActive(false);
+
+                // Only hide if it is in our replay list. 
+                // If it's not in the list, it's either a default item or something we didn't buy, so we shouldn't touch it.
+                // Assuming defaults are correctly set up in the scene before this.
+                if (replayItemNames.Contains(behaviour.visualObject.name.ToLower()))
+                {
+                    if (behaviour.hasDefaultVariation)
+                    {
+                        behaviour.ShowDefaultVariation();
+                    }
+                    else
+                    {
+                        behaviour.Hide();
+                    }
+                }
+            }
+        }
+
+        yield return new WaitForSeconds(0.5f);
+
+        // Replay
+        foreach (string itemName in roomData.unlockedItems)
+        {
+            VisualObjectBehaviour behaviour = scene.GetBehaviour(itemName.ToLower());
+            if (behaviour != null)
+            {
+                // Show particle effect
+                if (screen.visualObjectParticles != null)
+                {
+                    screen.visualObjectParticles.CreateParticles(VisualObjectParticles.PositionType.BuySuccess, scene.rootTransform.gameObject, behaviour);
+                    GGSoundSystem.Play(GGSoundSystem.SFXType.ButtonConfirm);
+                }
+
+                behaviour.SetVisualState(); // Use existing logic to show the correct variation
+                yield return new WaitForSeconds(0.4f); // Delay between items
+            }
+        }
+
+        yield return new WaitForSeconds(1.0f);
+
+        // Logic split: If onComplete has been provided, we assume the caller handles the next steps (like showing Win Screen).
+        // If not, we restore the screen state ourselves.
+        if (onComplete != null)
+        {
+            screen.Init(); // Still need to restore scene state just in case, but let callback handle UI
+            onComplete();
+        }
+        else
+        {
+             screen.Init();
+        }
+    }
+}

--- a/Assets/Scripts/VisualObjectBehaviour.cs
+++ b/Assets/Scripts/VisualObjectBehaviour.cs
@@ -251,6 +251,11 @@ public class VisualObjectBehaviour : MonoBehaviour
         }
     }
 
+    public void ShowDefaultVariation()
+    {
+        this.ShowVariation(this.defaultVariation);
+    }
+
     public void Hide()
     {
         this.ShowVariation(null);

--- a/Assets/Scripts/WellDoneContainer.cs
+++ b/Assets/Scripts/WellDoneContainer.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.Playables;
 
 public class WellDoneContainer : MonoBehaviour
@@ -23,8 +24,15 @@ public class WellDoneContainer : MonoBehaviour
 		{
 			this.runningAnimation = this.DoShowSingleAnimation();
 		}
-		this.runningAnimation.MoveNext();
-		GGSoundSystem.Play(GGSoundSystem.SFXType.YouWinAnimation);
+        this.runningAnimation.MoveNext();
+        GGSoundSystem.Play(GGSoundSystem.SFXType.YouWinAnimation);
+
+        if (this.replayButton != null)
+        {
+            GGUtil.SetActive(this.replayButton, this.initArguments.onReplay != null);
+            this.replayButton.onClick.RemoveAllListeners();
+            this.replayButton.onClick.AddListener(this.OnReplayClicked);
+        }
 	}
 
 	public void Hide()
@@ -74,7 +82,18 @@ public class WellDoneContainer : MonoBehaviour
 		}
 	}
 
-	[SerializeField]
+    [SerializeField]
+    public Button replayButton;
+
+    private void OnReplayClicked()
+    {
+        if (this.initArguments.onReplay != null)
+        {
+            this.initArguments.onReplay();
+        }
+    }
+
+    [SerializeField]
 	private string inStateName;
 
 	[SerializeField]
@@ -108,6 +127,7 @@ public class WellDoneContainer : MonoBehaviour
 		public InitArguments(Action onComplete)
 		{
 			this.onComplete = onComplete;
+            this.onReplay = null;
 		}
 
 		public void CallOnComplete()
@@ -120,6 +140,7 @@ public class WellDoneContainer : MonoBehaviour
 		}
 
 		public Action onComplete;
+		public Action onReplay;
 	}
 
 	private sealed class _003CDoShowAnimatioDirector_003Ed__12 : IEnumerator<object>, IEnumerator, IDisposable


### PR DESCRIPTION
## Summary
Implemented a fully functional replay system for room decorations.

## Changes
- [ReplayManager.cs](Assets/Scripts/ReplayManager.cs): Handles recording and playback with "Initial State" support.
- [DecorateRoomScreen.cs](Assets/Scripts/DecorateRoomScreen.cs): Triggers auto-replay before "Well Done" screen.
- `EditorExtensions`: Added 'Reset Game' and 'Give 100 Stars' tools.

## Verification
- Verified auto-replay loop works correctly.
- Verified "Black Screen" fix (default items remain visible).
- Verified navigation flow (no loops).
Closes #8 