### PR TITLE
Fix compiler and shader errors (fixes #10)

### DIFF
--- a/Assets/Scripts/WellDoneScreen.cs
+++ b/Assets/Scripts/WellDoneScreen.cs
@@ -57,6 +57,8 @@ public class WellDoneScreen : MonoBehaviour
 		public string mainText;
 
 		public Action onComplete;
+
+		public Action onReplay;
 	}
 
 	private sealed class _003C_003Ec__DisplayClass7_0
@@ -101,6 +103,7 @@ public class WellDoneScreen : MonoBehaviour
 				WellDoneContainer.InitArguments initArguments = default(WellDoneContainer.InitArguments);
 				this._003C_003E8__1.complete = false;
 				initArguments.onComplete = new Action(this._003C_003E8__1._003CDoAnimation_003Eb__0);
+				initArguments.onReplay = wellDoneScreen.initArguments.onReplay;
 				wellDoneScreen.container.Show(initArguments);
 			}
 			if (this._003C_003E8__1.complete)

--- a/Assets/TextMesh Pro/Shaders/TMP_SDF SSD.shader
+++ b/Assets/TextMesh Pro/Shaders/TMP_SDF SSD.shader
@@ -124,8 +124,8 @@ SubShader {
 
         #include "UnityCG.cginc"
         #include "UnityUI.cginc"
-        #include "TMPro_Properties.cginc"
-        #include "TMPro.cginc"
+        #include "../Resources/Shaders/TMPro_Properties.cginc"
+        #include "../Resources/Shaders/TMPro.cginc"
 
         struct vertex_t {
             UNITY_VERTEX_INPUT_INSTANCE_ID

--- a/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile SSD.shader
+++ b/Assets/TextMesh Pro/Shaders/TMP_SDF-Mobile SSD.shader
@@ -94,7 +94,7 @@ SubShader {
 
 		#include "UnityCG.cginc"
 		#include "UnityUI.cginc"
-		#include "TMPro_Properties.cginc"
+		#include "../Resources/Shaders/TMPro_Properties.cginc"
 
 		#include "TMPro_Mobile.cginc"
 


### PR DESCRIPTION
## Description
This Pull Request fixes a compiler error and two shader include errors that were preventing the project from building successfully.

## Changes
1.  **Fixed Compiler Error (CS1061):**
    *   Added the missing `onReplay` field to the `WellDoneScreen.InitArguments` struct.
    *   Updated [WellDoneScreen.cs] to pass the `onReplay` callback to the [WellDoneContainer].
    *   This resolves the mismatch referenced in [DecorateRoomScreen.cs].

2.  **Fixed Shader Errors:**
    *   Updated `#include` paths in `TMP_SDF SSD.shader` and `TMP_SDF-Mobile SSD.shader`.
    *   Changed paths from `"TMPro_Properties.cginc"` to `../Resources/Shaders/TMPro_Properties.cginc"` to correctly locate the files.

## Related Issue
Closes #10